### PR TITLE
fix(gs): disk.rb comparison helpers

### DIFF
--- a/lib/gemstone/disk.rb
+++ b/lib/gemstone/disk.rb
@@ -32,6 +32,18 @@ module Lich
         end
       end
 
+      def ==(other)
+        other.is_a?(Disk) && other.id == self.id
+      end
+
+      def eql?(other)
+        self == other
+      end
+
+      def hash
+        id.hash
+      end
+
       def method_missing(method, *args)
         GameObj[@id].send(method, *args)
       end


### PR DESCRIPTION
When doing Disk.all - Group.disks it does not compare the way we want because the address? is different.

```
;eq Disk.all
[exec1: [#<Lich::Gemstone::Disk:0x000001ed7d0c2620 @id="722016115", @name="Nisugi">]]
;eq Group.disks
[exec1: [#<Lich::Gemstone::Disk:0x000001ed744b28b0 @id="722016115", @name="Nisugi">]]
;eq Disk.all - Group.disks
[exec1: [#<Lich::Gemstone::Disk:0x000001ed7dcba518 @id="722016115", @name="Nisugi">]]
```

The three helper methods cause the subtraction to be based on id instead of the entire hash.
With the changes, Disk.all - Group.disks returns []